### PR TITLE
Add support for multiple cli_version_args

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -19,6 +19,8 @@ cli_version_arg = -V
 version = 2
 ```
 
+To pass multiple args, use spaces as separators.
+
 If the program lacks a specific argument to display its version, but contains version information in the default output, include an empty `cli_version_arg` setting:
 
 ```ini

--- a/verchew/script.py
+++ b/verchew/script.py
@@ -280,7 +280,7 @@ def get_version(program, argument=None):
     if argument is None:
         args = [program, '--version']
     elif argument:
-        args = [program, argument]
+        args = [program] + argument.split()
     else:
         args = [program]
 

--- a/verchew/tests/test_script.py
+++ b/verchew/tests/test_script.py
@@ -146,6 +146,9 @@ def describe_get_version():
     def with_custom_argument():
         expect(get_version('python', argument='-V')).contains("Python ")
 
+    def with_multiple_arguments():
+        expect(get_version('python', argument='-V -V')).contains("Python ")
+
     def with_no_argument():
         expect(get_version('pip', argument='')).contains("Usage:")
 


### PR DESCRIPTION
Add the ability to pass multiple `cli_version_args` in the configuration. This is useful when a separate program is needed to search for the program you actually care about, such as using `vswhere` to find Visual Studio. For example:

```ini
[Visual Studio 2019]

cli = vswhere
cli_version_arg = -version 16 -property installationVersion
version = 16
```