### PR TITLE
Fix optional=false

### DIFF
--- a/verchew/script.py
+++ b/verchew/script.py
@@ -35,6 +35,7 @@ import os
 import re
 import sys
 from collections import OrderedDict
+from distutils.util import strtobool
 from subprocess import PIPE, STDOUT, Popen
 
 
@@ -252,7 +253,7 @@ def check_dependencies(config):
                 success.append(_("~"))
                 break
         else:
-            if settings.get('optional'):
+            if strtobool(settings.get('optional', 'false')):
                 show(_("?") + " EXPECTED (OPTIONAL): {0}".format(settings['version']))
                 success.append(_("?"))
             else:

--- a/verchew/script.py
+++ b/verchew/script.py
@@ -35,7 +35,6 @@ import os
 import re
 import sys
 from collections import OrderedDict
-from distutils.util import strtobool
 from subprocess import PIPE, STDOUT, Popen
 
 
@@ -237,6 +236,8 @@ def parse_config(path):
         data[name]['version'] = version
         data[name]['patterns'] = [v.strip() for v in version.split('||')]
 
+        data[name]['optional'] = data[name].get('optional', 'false').strip().lower() in ('true', 'yes', 'y', True)
+
     return data
 
 
@@ -253,7 +254,7 @@ def check_dependencies(config):
                 success.append(_("~"))
                 break
         else:
-            if strtobool(settings.get('optional', 'false')):
+            if settings.get('optional'):
                 show(_("?") + " EXPECTED (OPTIONAL): {0}".format(settings['version']))
                 success.append(_("?"))
             else:

--- a/verchew/script.py
+++ b/verchew/script.py
@@ -236,7 +236,9 @@ def parse_config(path):
         data[name]['version'] = version
         data[name]['patterns'] = [v.strip() for v in version.split('||')]
 
-        data[name]['optional'] = data[name].get('optional', 'false').strip().lower() in ('true', 'yes', 'y', True)
+        data[name]['optional'] = data[name].get(
+            'optional', 'false'
+        ).strip().lower() in ('true', 'yes', 'y', True)
 
     return data
 

--- a/verchew/tests/test_script.py
+++ b/verchew/tests/test_script.py
@@ -119,7 +119,12 @@ def describe_parse_config():
         )
 
         expect(parse_config(str(config))) == {
-            'Foobar': {'cli': 'foobar', 'version': 'v1.2.3', 'patterns': ['v1.2.3'], 'optional': True}
+            'Foobar': {
+                'cli': 'foobar',
+                'version': 'v1.2.3',
+                'patterns': ['v1.2.3'],
+                'optional': True,
+            }
         }
 
     def with_multiple_versions(config):
@@ -133,7 +138,11 @@ def describe_parse_config():
         )
 
         expect(parse_config(str(config))) == {
-            'Foobar': {'version': '2 || 3 ||     4', 'patterns': ['2', '3', '4'], 'optional': False}
+            'Foobar': {
+                'version': '2 || 3 ||     4',
+                'patterns': ['2', '3', '4'],
+                'optional': False,
+            }
         }
 
 

--- a/verchew/tests/test_script.py
+++ b/verchew/tests/test_script.py
@@ -103,7 +103,7 @@ def describe_parse_config():
         )
 
         expect(parse_config(str(config))) == {
-            'Foobar': {'version': '', 'patterns': ['']}
+            'Foobar': {'version': '', 'patterns': [''], 'optional': False}
         }
 
     def with_a_filled_section(config):
@@ -114,11 +114,12 @@ def describe_parse_config():
 
         cli = foobar
         version = v1.2.3
+        optional = true
         """,
         )
 
         expect(parse_config(str(config))) == {
-            'Foobar': {'cli': 'foobar', 'version': 'v1.2.3', 'patterns': ['v1.2.3']}
+            'Foobar': {'cli': 'foobar', 'version': 'v1.2.3', 'patterns': ['v1.2.3'], 'optional': True}
         }
 
     def with_multiple_versions(config):
@@ -132,7 +133,7 @@ def describe_parse_config():
         )
 
         expect(parse_config(str(config))) == {
-            'Foobar': {'version': '2 || 3 ||     4', 'patterns': ['2', '3', '4']}
+            'Foobar': {'version': '2 || 3 ||     4', 'patterns': ['2', '3', '4'], 'optional': False}
         }
 
 


### PR DESCRIPTION
`optional=false` in the config file was being treated as `True`, since Python counts all strings as truthy.

This PR converts the string to a `bool` first so that `optional=false` is treated the same as not specifying `optional` at all.

I couldn't find a clean way to add unit tests for this, since the logic is inside `check_dependencies()`. If you prefer, I can spend some more time trying to unit test this properly.